### PR TITLE
Fix: 감상문 작성 시 검색 결과의 정보를 받아오도록 수정

### DIFF
--- a/js/movieApi.js
+++ b/js/movieApi.js
@@ -7,18 +7,16 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const serviceKey = 'NE98FTD75W4C0R4JS785';
+import { MOVIE_URL } from './BASE_URL.js';
+const serviceKey = '노션에 있는 한국영화자료원 인증키';
 const getMovieInfo = (movieSeq) => __awaiter(void 0, void 0, void 0, function* () {
-    const url = 
-    // MOVIE_URL +
-    // `&ServiceKey=&detail=Y&movieSeq=${getValue}`;
-    `https://api.koreafilm.or.kr/openapi-data2/wisenut/search_api/search_json2.jsp?collection=kmdb_new2&ServiceKey=${serviceKey}&detail=Y&${movieSeq}`;
+    const url = MOVIE_URL + `&ServiceKey=${serviceKey}&detail=Y&${movieSeq}`;
+    // `https://api.koreafilm.or.kr/openapi-data2/wisenut/search_api/search_json2.jsp?collection=kmdb_new2&ServiceKey=${serviceKey}&detail=Y&${movieSeq}`;
     try {
         const response = yield fetch(url, {
             method: 'GET',
         });
         const json = yield response.json();
-        console.log(json.Data[0].Result[0]);
         return json.Data[0].Result[0];
     }
     catch (err) {

--- a/js/movieApi.js
+++ b/js/movieApi.js
@@ -1,0 +1,28 @@
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+const serviceKey = 'NE98FTD75W4C0R4JS785';
+const getMovieInfo = (movieSeq) => __awaiter(void 0, void 0, void 0, function* () {
+    const url = 
+    // MOVIE_URL +
+    // `&ServiceKey=&detail=Y&movieSeq=${getValue}`;
+    `https://api.koreafilm.or.kr/openapi-data2/wisenut/search_api/search_json2.jsp?collection=kmdb_new2&ServiceKey=${serviceKey}&detail=Y&${movieSeq}`;
+    try {
+        const response = yield fetch(url, {
+            method: 'GET',
+        });
+        const json = yield response.json();
+        console.log(json.Data[0].Result[0]);
+        return json.Data[0].Result[0];
+    }
+    catch (err) {
+        console.error(err);
+    }
+});
+export { getMovieInfo };

--- a/js/movieApi.ts
+++ b/js/movieApi.ts
@@ -1,19 +1,16 @@
 import { MOVIE_URL } from './BASE_URL.js';
 
-const serviceKey = 'NE98FTD75W4C0R4JS785';
+const serviceKey = '노션에 있는 한국영화자료원 인증키';
 
 const getMovieInfo = async (movieSeq: string) => {
-    const url =
-        // MOVIE_URL +
-        // `&ServiceKey=&detail=Y&movieSeq=${getValue}`;
-        `https://api.koreafilm.or.kr/openapi-data2/wisenut/search_api/search_json2.jsp?collection=kmdb_new2&ServiceKey=${serviceKey}&detail=Y&${movieSeq}`;
+    const url = MOVIE_URL + `&ServiceKey=${serviceKey}&detail=Y&${movieSeq}`;
+    // `https://api.koreafilm.or.kr/openapi-data2/wisenut/search_api/search_json2.jsp?collection=kmdb_new2&ServiceKey=${serviceKey}&detail=Y&${movieSeq}`;
 
     try {
         const response = await fetch(url, {
             method: 'GET',
         });
         const json = await response.json();
-        console.log(json.Data[0].Result[0]);
         return json.Data[0].Result[0];
     } catch (err) {
         console.error(err);

--- a/js/movieApi.ts
+++ b/js/movieApi.ts
@@ -1,0 +1,23 @@
+import { MOVIE_URL } from './BASE_URL.js';
+
+const serviceKey = 'NE98FTD75W4C0R4JS785';
+
+const getMovieInfo = async (movieSeq: string) => {
+    const url =
+        // MOVIE_URL +
+        // `&ServiceKey=&detail=Y&movieSeq=${getValue}`;
+        `https://api.koreafilm.or.kr/openapi-data2/wisenut/search_api/search_json2.jsp?collection=kmdb_new2&ServiceKey=${serviceKey}&detail=Y&${movieSeq}`;
+
+    try {
+        const response = await fetch(url, {
+            method: 'GET',
+        });
+        const json = await response.json();
+        console.log(json.Data[0].Result[0]);
+        return json.Data[0].Result[0];
+    } catch (err) {
+        console.error(err);
+    }
+};
+
+export { getMovieInfo };

--- a/js/searchResult.js
+++ b/js/searchResult.js
@@ -1,5 +1,3 @@
-"use strict";
-// import { MOVIE_URL } from './BASE_URL.js';
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -9,6 +7,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+import { getMovieInfo } from './movieApi.js';
 const title = document.querySelector('.movie-title');
 const titleEng = document.querySelector('.sub-movie-title');
 const poster = document.querySelector('.poster-card');
@@ -24,27 +23,25 @@ const movieSeq = window.location.search.slice(1);
 postReview.addEventListener('click', () => {
     window.location.href = `../pages/writePost.html?${movieSeq}`;
 });
-function getMovieInfo() {
-    return __awaiter(this, void 0, void 0, function* () {
-        const url = 
-        // MOVIE_URL +
-        // `&ServiceKey=&detail=Y&movieSeq=${getValue}`;
-        `https://api.koreafilm.or.kr/openapi-data2/wisenut/search_api/search_json2.jsp?collection=kmdb_new2&ServiceKey=&detail=Y&${movieSeq}`;
-        try {
-            const response = yield fetch(url, {
-                method: 'GET',
-            });
-            const json = yield response.json();
-            showValue(json.Data[0].Result[0]);
-            console.log(json.Data[0].Result[0]);
-        }
-        catch (err) {
-            console.error(err);
-        }
-    });
-}
+// async function getMovieInfo(code:string) {
+//     const url =
+//         // MOVIE_URL +
+//         // `&ServiceKey=&detail=Y&movieSeq=${getValue}`;
+//         `https://api.koreafilm.or.kr/openapi-data2/wisenut/search_api/search_json2.jsp?collection=kmdb_new2&ServiceKey=NE98FTD75W4C0R4JS785&detail=Y&${code}`;
+//     try {
+//         const response = await fetch(url, {
+//             method: 'GET',
+//         });
+//         const json = await response.json();
+//         console.log(json.Data[0].Result[0]);
+//         return json.Data[0].Result[0];
+//     } catch (err) {
+//         console.error(err);
+//     }
+// }
 window.addEventListener('load', () => __awaiter(void 0, void 0, void 0, function* () {
-    yield getMovieInfo();
+    const movieInfo = yield getMovieInfo(movieSeq);
+    showValue(movieInfo);
 }));
 const showValue = (movie) => {
     title.textContent = movie.title;

--- a/js/searchResult.ts
+++ b/js/searchResult.ts
@@ -1,4 +1,4 @@
-// import { MOVIE_URL } from './BASE_URL.js';
+import { getMovieInfo } from './movieApi.js';
 
 interface MovieLists {
     title: string;
@@ -51,26 +51,9 @@ postReview!.addEventListener('click', () => {
     window.location.href = `../pages/writePost.html?${movieSeq}`;
 });
 
-async function getMovieInfo() {
-    const url =
-        // MOVIE_URL +
-        // `&ServiceKey=&detail=Y&movieSeq=${getValue}`;
-        `https://api.koreafilm.or.kr/openapi-data2/wisenut/search_api/search_json2.jsp?collection=kmdb_new2&ServiceKey=&detail=Y&${movieSeq}`;
-
-    try {
-        const response = await fetch(url, {
-            method: 'GET',
-        });
-        const json = await response.json();
-        showValue(json.Data[0].Result[0]);
-        console.log(json.Data[0].Result[0]);
-    } catch (err) {
-        console.error(err);
-    }
-}
-
 window.addEventListener('load', async () => {
-    await getMovieInfo();
+    const movieInfo = await getMovieInfo(movieSeq);
+    showValue(movieInfo);
 });
 
 const showValue = (movie: MovieLists) => {

--- a/js/writePost.js
+++ b/js/writePost.js
@@ -8,6 +8,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 import { handleUploadImage } from './imageApi.js';
+import { getMovieInfo } from './movieApi.js';
 import { writeReview } from './reviewApi.js';
 const movieTitle = document.querySelector('#movie-title');
 const movieSubTitle = document.querySelector('#movie-title-eng');
@@ -17,9 +18,14 @@ const imgReview = document.querySelector('#img-review');
 const imgInput = document.querySelector('#img-input');
 const textReview = document.querySelector('#text-review');
 const saveButton = document.querySelector('#btn-save');
+const movieSeq = window.location.search.slice(1);
+// const queryString = window.location.search;
+// const params = new URLSearchParams(queryString);
+// const movieSeq = params.get('movieSeq');
 // 서버로 전송할 이미지 (파일 정보가 담김)
 let img;
 const IMG_MAX_SIZE = 10 * 1024 * 1024;
+let imgUrl = '';
 const fileTypeArray = [
     'image/gif',
     'image/jpeg',
@@ -41,7 +47,6 @@ const setTextHeight = (e) => {
 // 감상문 업로드
 const handleUploadReview = (e) => __awaiter(void 0, void 0, void 0, function* () {
     e.preventDefault();
-    let imgUrl = '';
     if (textRating.textContent === '') {
         alert('별점을 입력해주세요.');
         return;
@@ -64,6 +69,21 @@ const handleUploadReview = (e) => __awaiter(void 0, void 0, void 0, function* ()
     const postId = yield writeReview(reqData);
     window.location.href = `/pages/reviewDetail.html?id=${postId}`;
 });
+window.addEventListener('load', () => __awaiter(void 0, void 0, void 0, function* () {
+    if (movieSeq !== null) {
+        const movieInfo = yield getMovieInfo(movieSeq);
+        movieTitle.textContent = movieInfo.title;
+        if (movieInfo.titleEng !== '') {
+            movieSubTitle.textContent = movieInfo.titleEng;
+        }
+        else {
+            movieSubTitle.textContent = movieInfo.titleOrg;
+        }
+        if (movieInfo.posters !== '') {
+            imgUrl = movieInfo.posters.substring(0, 60);
+        }
+    }
+}));
 imgInput.addEventListener('change', (e) => {
     const fileReader = new FileReader();
     const target = e.currentTarget;

--- a/js/writePost.ts
+++ b/js/writePost.ts
@@ -1,4 +1,5 @@
 import { handleUploadImage } from './imageApi.js';
+import { getMovieInfo } from './movieApi.js';
 import { writeReview } from './reviewApi.js';
 
 const movieTitle = document.querySelector(
@@ -14,9 +15,15 @@ const imgInput = document.querySelector('#img-input') as HTMLInputElement;
 const textReview = document.querySelector('#text-review') as HTMLInputElement;
 const saveButton = document.querySelector('#btn-save') as HTMLButtonElement;
 
+const movieSeq = window.location.search.slice(1);
+// const queryString = window.location.search;
+// const params = new URLSearchParams(queryString);
+// const movieSeq = params.get('movieSeq');
+
 // 서버로 전송할 이미지 (파일 정보가 담김)
 let img: File;
 const IMG_MAX_SIZE = 10 * 1024 * 1024;
+let imgUrl: String = '';
 
 const fileTypeArray: string[] = [
     'image/gif',
@@ -40,7 +47,6 @@ const setTextHeight = (e: Event) => {
 // 감상문 업로드
 const handleUploadReview = async (e: Event) => {
     e.preventDefault();
-    let imgUrl: String = '';
     if (textRating.textContent === '') {
         alert('별점을 입력해주세요.');
         return;
@@ -64,6 +70,21 @@ const handleUploadReview = async (e: Event) => {
     const postId = await writeReview(reqData);
     window.location.href = `/pages/reviewDetail.html?id=${postId}`;
 };
+
+window.addEventListener('load', async () => {
+    if (movieSeq !== null) {
+        const movieInfo = await getMovieInfo(movieSeq);
+        movieTitle.textContent = movieInfo.title;
+        if (movieInfo.titleEng !== '') {
+            movieSubTitle.textContent = movieInfo.titleEng;
+        } else {
+            movieSubTitle.textContent = movieInfo.titleOrg;
+        }
+        if (movieInfo.posters !== '') {
+            imgUrl = movieInfo.posters.substring(0, 60);
+        }
+    }
+});
 
 imgInput.addEventListener('change', (e: Event) => {
     const fileReader = new FileReader();

--- a/pages/searchResult.html
+++ b/pages/searchResult.html
@@ -92,6 +92,6 @@
                 </button>
             </div>
         </div>
-        <script src="../js/searchResult.js"></script>
+        <script type="module" src="../js/searchResult.js"></script>
     </body>
 </html>


### PR DESCRIPTION
- close #88 close #136 
- 검색 결과 페이지에서 감상문 작성하기 버튼 누르면 그 페이지의 영화 정보(제목, 영제목, 포스터)를 감상문 작성 페이지로 가져오도록 변경했습니다.
- 이미지가 첨부되지 않으면 영화의 포스터가 기본 이미지로 들어갑니다. 포스터가 없는 경우에는 이미지 주소가 아예 비겠지만 예외처리 하셨으니 괜찮을 거 같습니다!
- 영화 1개의 정보 받아오는 함수만 우선 `movieApi`에 따로 분리했습니다. 영화 api를 사용하는 다른 함수들도 분리해 보겠습니다!  #91 
-  .env가 노드 환경에서만 적용이 되어서 바닐라로는 프론트엔드 선에서 인증키를 온전히 숨길 수 있는 방법이 없다고 합니다. 그래도 우선 서비스키는  지워두었습니다.