### PR TITLE
Fix: 영화 정보 불러올 때 movieId도 같이 검색하도록 수정

### DIFF
--- a/js/movieApi.js
+++ b/js/movieApi.js
@@ -8,15 +8,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 import { MOVIE_URL } from './BASE_URL.js';
-const serviceKey = '노션에 있는 한국영화자료원 인증키';
-const getMovieInfo = (movieSeq) => __awaiter(void 0, void 0, void 0, function* () {
-    const url = MOVIE_URL + `&ServiceKey=${serviceKey}&detail=Y&${movieSeq}`;
+const serviceKey = 'NE98FTD75W4C0R4JS785';
+const getMovieInfo = (movieId, movieSeq) => __awaiter(void 0, void 0, void 0, function* () {
+    const url = MOVIE_URL +
+        `&ServiceKey=${serviceKey}&detail=Y&movieId=${movieId}&movieSeq=${movieSeq}`;
     // `https://api.koreafilm.or.kr/openapi-data2/wisenut/search_api/search_json2.jsp?collection=kmdb_new2&ServiceKey=${serviceKey}&detail=Y&${movieSeq}`;
     try {
         const response = yield fetch(url, {
             method: 'GET',
         });
         const json = yield response.json();
+        console.log(json.Data[0].Result[0]);
         return json.Data[0].Result[0];
     }
     catch (err) {

--- a/js/movieApi.ts
+++ b/js/movieApi.ts
@@ -1,9 +1,11 @@
 import { MOVIE_URL } from './BASE_URL.js';
 
-const serviceKey = '노션에 있는 한국영화자료원 인증키';
+const serviceKey = 'NE98FTD75W4C0R4JS785';
 
-const getMovieInfo = async (movieSeq: string) => {
-    const url = MOVIE_URL + `&ServiceKey=${serviceKey}&detail=Y&${movieSeq}`;
+const getMovieInfo = async (movieId: string, movieSeq: string) => {
+    const url =
+        MOVIE_URL +
+        `&ServiceKey=${serviceKey}&detail=Y&movieId=${movieId}&movieSeq=${movieSeq}`;
     // `https://api.koreafilm.or.kr/openapi-data2/wisenut/search_api/search_json2.jsp?collection=kmdb_new2&ServiceKey=${serviceKey}&detail=Y&${movieSeq}`;
 
     try {
@@ -11,6 +13,7 @@ const getMovieInfo = async (movieSeq: string) => {
             method: 'GET',
         });
         const json = await response.json();
+        console.log(json.Data[0].Result[0]);
         return json.Data[0].Result[0];
     } catch (err) {
         console.error(err);

--- a/js/searchResult.js
+++ b/js/searchResult.js
@@ -19,29 +19,19 @@ const runtime = document.querySelector('.runtime');
 const rating = document.querySelector('.rating');
 const summary = document.querySelector('.movie-summary>dd');
 const postReview = document.querySelector('.container-review-btn>button');
-const movieSeq = window.location.search.slice(1);
+// const movieSeq = window.location.search.slice(1);
+const queryString = window.location.search;
+const params = new URLSearchParams(queryString);
+const movieId = params.get('movieId');
+const movieSeq = params.get('movieSeq');
 postReview.addEventListener('click', () => {
-    window.location.href = `../pages/writePost.html?${movieSeq}`;
+    window.location.href = `../pages/writePost.html?movieId=${movieId}&movieSeq=${movieSeq}`;
 });
-// async function getMovieInfo(code:string) {
-//     const url =
-//         // MOVIE_URL +
-//         // `&ServiceKey=&detail=Y&movieSeq=${getValue}`;
-//         `https://api.koreafilm.or.kr/openapi-data2/wisenut/search_api/search_json2.jsp?collection=kmdb_new2&ServiceKey=NE98FTD75W4C0R4JS785&detail=Y&${code}`;
-//     try {
-//         const response = await fetch(url, {
-//             method: 'GET',
-//         });
-//         const json = await response.json();
-//         console.log(json.Data[0].Result[0]);
-//         return json.Data[0].Result[0];
-//     } catch (err) {
-//         console.error(err);
-//     }
-// }
 window.addEventListener('load', () => __awaiter(void 0, void 0, void 0, function* () {
-    const movieInfo = yield getMovieInfo(movieSeq);
-    showValue(movieInfo);
+    if (movieId !== null && movieSeq !== null) {
+        const movieInfo = yield getMovieInfo(movieId, movieSeq);
+        showValue(movieInfo);
+    }
 }));
 const showValue = (movie) => {
     title.textContent = movie.title;

--- a/js/searchResult.ts
+++ b/js/searchResult.ts
@@ -45,15 +45,21 @@ const runtime = document.querySelector('.runtime');
 const rating = document.querySelector('.rating');
 const summary = document.querySelector('.movie-summary>dd') as HTMLElement;
 const postReview = document.querySelector('.container-review-btn>button');
-const movieSeq = window.location.search.slice(1);
+// const movieSeq = window.location.search.slice(1);
+const queryString = window.location.search;
+const params = new URLSearchParams(queryString);
+const movieId = params.get('movieId');
+const movieSeq = params.get('movieSeq');
 
 postReview!.addEventListener('click', () => {
-    window.location.href = `../pages/writePost.html?${movieSeq}`;
+    window.location.href = `../pages/writePost.html?movieId=${movieId}&movieSeq=${movieSeq}`;
 });
 
 window.addEventListener('load', async () => {
-    const movieInfo = await getMovieInfo(movieSeq);
-    showValue(movieInfo);
+    if (movieId !== null && movieSeq !== null) {
+        const movieInfo = await getMovieInfo(movieId, movieSeq);
+        showValue(movieInfo);
+    }
 });
 
 const showValue = (movie: MovieLists) => {

--- a/js/writePost.js
+++ b/js/writePost.js
@@ -18,10 +18,11 @@ const imgReview = document.querySelector('#img-review');
 const imgInput = document.querySelector('#img-input');
 const textReview = document.querySelector('#text-review');
 const saveButton = document.querySelector('#btn-save');
-const movieSeq = window.location.search.slice(1);
-// const queryString = window.location.search;
-// const params = new URLSearchParams(queryString);
-// const movieSeq = params.get('movieSeq');
+// const movieSeq = window.location.search.slice(1);
+const queryString = window.location.search;
+const params = new URLSearchParams(queryString);
+const movieId = params.get('movieId');
+const movieSeq = params.get('movieSeq');
 // 서버로 전송할 이미지 (파일 정보가 담김)
 let img;
 const IMG_MAX_SIZE = 10 * 1024 * 1024;
@@ -70,8 +71,8 @@ const handleUploadReview = (e) => __awaiter(void 0, void 0, void 0, function* ()
     window.location.href = `/pages/reviewDetail.html?id=${postId}`;
 });
 window.addEventListener('load', () => __awaiter(void 0, void 0, void 0, function* () {
-    if (movieSeq !== null) {
-        const movieInfo = yield getMovieInfo(movieSeq);
+    if (movieId !== null && movieSeq !== null) {
+        const movieInfo = yield getMovieInfo(movieId, movieSeq);
         movieTitle.textContent = movieInfo.title;
         if (movieInfo.titleEng !== '') {
             movieSubTitle.textContent = movieInfo.titleEng;

--- a/js/writePost.ts
+++ b/js/writePost.ts
@@ -15,10 +15,11 @@ const imgInput = document.querySelector('#img-input') as HTMLInputElement;
 const textReview = document.querySelector('#text-review') as HTMLInputElement;
 const saveButton = document.querySelector('#btn-save') as HTMLButtonElement;
 
-const movieSeq = window.location.search.slice(1);
-// const queryString = window.location.search;
-// const params = new URLSearchParams(queryString);
-// const movieSeq = params.get('movieSeq');
+// const movieSeq = window.location.search.slice(1);
+const queryString = window.location.search;
+const params = new URLSearchParams(queryString);
+const movieId = params.get('movieId');
+const movieSeq = params.get('movieSeq');
 
 // 서버로 전송할 이미지 (파일 정보가 담김)
 let img: File;
@@ -72,8 +73,8 @@ const handleUploadReview = async (e: Event) => {
 };
 
 window.addEventListener('load', async () => {
-    if (movieSeq !== null) {
-        const movieInfo = await getMovieInfo(movieSeq);
+    if (movieId !== null && movieSeq !== null) {
+        const movieInfo = await getMovieInfo(movieId, movieSeq);
         movieTitle.textContent = movieInfo.title;
         if (movieInfo.titleEng !== '') {
             movieSubTitle.textContent = movieInfo.titleEng;


### PR DESCRIPTION
- 영화 검색 시 코드 앞자리가 `F`랑 `K`로 나뉘는데 번호로만 검색하면 앞자리가 `F`로 고정되어서 다른 영화의 정보가 뜨던 문제가 있었습니다. #140 
- 검색 상세 페이지, 감상문 작성 페이지에서 movieId와 movieSeq를 동시에 요청하게 수정하였습니다.
- 이슈 닫는 건 @etoile-j 님께서 부탁드립니다!