### PR TITLE
Design: 다른 비율 포스터 표출 수정 및 애니메이션 추가

### DIFF
--- a/pages/searchResult.html
+++ b/pages/searchResult.html
@@ -41,8 +41,7 @@
                 <li></li>
             </ul>
         </header>
-        <main class="search-result-main">
-            <!-- <h2 class="text-heading page-title">영화 검색 결과</h2> -->
+        <main class="search-result-main main">
             <article class="movie-article">
                 <h2 class="movie-title page-title">영화 제목 라라랜드 라라</h2>
                 <h3 class="sub-movie-title">english title english title</h3>

--- a/styles/pages/searchResult.css
+++ b/styles/pages/searchResult.css
@@ -30,7 +30,7 @@
   right: 33px;
   width: 25px;
   height: 25px;
-  background: url(../../assets/icons/menu.svg) no-repeat 0 0;
+  background: url("../../assets/icons/menu.svg") no-repeat 0 0;
 }
 
 .nav {
@@ -53,7 +53,7 @@
   color: #ff5f5f;
 }
 
-.nav li a .selected {
+.nav li a.selected {
   color: #ff5f5f;
 }
 
@@ -63,7 +63,16 @@
   min-height: calc(100vh - 150px);
 }
 
-.main.wrapper-etc {
+.wrapper-etc {
+  z-index: 100;
+  position: fixed;
+  top: 0;
+  left: 0;
+  margin-top: 90px;
+  min-height: calc(100vh - 150px);
+  width: 100%;
+  height: 100%;
+  background-color: #1e1e1e;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
@@ -77,19 +86,22 @@
   -webkit-box-align: center;
       -ms-flex-align: center;
           align-items: center;
-  margin-top: 250px;
   color: #f1f1f1;
 }
 
-.main.wrapper-etc .img-etc {
+.wrapper-etc .img-etc {
   width: 181px;
   margin-bottom: 20px;
 }
 
-.main.wrapper-etc .text-etc {
+.wrapper-etc .text-etc {
   margin-bottom: 30px;
   font-family: "SpoqaHanSansNeo-Bold", sans-serif;
   font-size: 25px;
+}
+
+.wrapper-etc.disabled {
+  display: none;
 }
 
 .footer {
@@ -125,7 +137,8 @@
             flex-direction: column;
   }
   .img-logo img {
-    margin-left: 0;
+    margin: 15px 0 0 0;
+    content: url("../../assets/icons/logo-title-s.svg");
   }
   .img-logo .btn-nav {
     display: block;
@@ -161,7 +174,7 @@
 }
 
 .search-result-main {
-  padding-top: 94px;
+  padding-top: 60px;
 }
 
 .text-heading {
@@ -175,10 +188,12 @@
   max-width: 550px;
   padding: 0px 20px;
   margin-bottom: 100px;
+  -webkit-animation: fadeIn 0.9s ease-in-out;
+          animation: fadeIn 0.9s ease-in-out;
 }
 
 .movie-article .movie-title {
-  margin: 60px 0 4px;
+  margin-bottom: 4px;
   padding: 0 5px 0;
   line-height: 38px;
   text-align: left;
@@ -205,6 +220,9 @@
 
 .card-info-wrapper .poster-card {
   margin-right: 30px;
+  width: 100%;
+  -o-object-fit: cover;
+     object-fit: cover;
 }
 
 .right-part {
@@ -273,6 +291,7 @@ div > dt {
   text-overflow: ellipsis;
   display: inline-block;
   white-space: nowrap;
+  word-break: keep-all;
   width: 185px;
 }
 
@@ -281,6 +300,7 @@ div > dt {
   text-overflow: ellipsis;
   display: inline-block;
   white-space: nowrap;
+  word-break: keep-all;
   width: 185px;
 }
 
@@ -294,7 +314,6 @@ div > dt {
             box-sizing: content-box;
   }
   .movie-article .movie-title {
-    margin: 50px 0 7px;
     font-size: 25px;
     line-height: 31px;
     text-align: center;
@@ -349,6 +368,7 @@ div > dt {
     text-overflow: ellipsis;
     display: inline-block;
     white-space: nowrap;
+    word-break: keep-all;
     width: 300px;
   }
   .actor {
@@ -356,6 +376,7 @@ div > dt {
     text-overflow: ellipsis;
     display: inline-block;
     white-space: nowrap;
+    word-break: keep-all;
     width: 300px;
   }
 }
@@ -375,5 +396,23 @@ div > dt {
   }
   to {
     padding-top: 10px;
+  }
+}
+
+@-webkit-keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
   }
 }

--- a/styles/pages/searchResult.css
+++ b/styles/pages/searchResult.css
@@ -382,7 +382,7 @@ div > dt {
 }
 
 @-webkit-keyframes motion {
-  form {
+  from {
     padding-top: 0px;
   }
   to {
@@ -391,7 +391,7 @@ div > dt {
 }
 
 @keyframes motion {
-  form {
+  from {
     padding-top: 0px;
   }
   to {

--- a/styles/pages/searchResult.scss
+++ b/styles/pages/searchResult.scss
@@ -3,7 +3,7 @@
 @import '../components/common';
 
 .search-result-main {
-    padding-top: 94px;
+    padding-top: 60px;
 }
 
 .text-heading {
@@ -17,8 +17,9 @@
     max-width: 550px;
     padding: 0px 20px;
     margin-bottom: 100px;
+    animation: fadeIn 0.9s ease-in-out;
     .movie-title {
-        margin: 60px 0 4px;
+        margin-bottom: 4px;
         padding: 0 5px 0;
         line-height: 38px;
         text-align: left;
@@ -39,6 +40,8 @@
     max-width: 550px;
     .poster-card {
         margin-right: 30px;
+        width: 100%;
+        object-fit: cover;
     }
 }
 
@@ -107,7 +110,6 @@ div > dt {
         margin-bottom: 100px;
         box-sizing: content-box;
         .movie-title {
-            margin: 50px 0 7px;
             font-size: 25px;
             line-height: 31px;
             text-align: center;
@@ -169,5 +171,14 @@ div > dt {
     }
     to {
         padding-top: 10px;
+    }
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
     }
 }

--- a/styles/pages/searchResult.scss
+++ b/styles/pages/searchResult.scss
@@ -166,7 +166,7 @@ div > dt {
 }
 
 @keyframes motion {
-    form {
+    from {
         padding-top: 0px;
     }
     to {


### PR DESCRIPTION
- searchResult 페이지 이런 비율 이상한 포스터들 원래 포스터 비율에 맞게 나오도록 조정
<img width="647" alt="스크린샷 2022-08-27 오후 4 51 33" src="https://user-images.githubusercontent.com/102905624/187022546-62498338-ff52-4b51-b976-9a5c360e47f6.png">

- `<main>` 태그에 main 클래스 추가
- fade in 애니메이션 추가

close #178 