### PR TITLE
Feature: 리뷰 작성/수정 시 이미지 삭제 기능 추가

### DIFF
--- a/assets/icons/icon-close.svg
+++ b/assets/icons/icon-close.svg
@@ -1,0 +1,29 @@
+<svg width="22" height="25" viewBox="0 0 22 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_11786_4304)">
+<g filter="url(#filter1_d_11786_4304)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M16.3536 6.35355C16.5488 6.15829 16.5488 5.84171 16.3536 5.64645C16.1583 5.45118 15.8417 5.45118 15.6464 5.64645L11 10.2929L6.35355 5.64645C6.15829 5.45118 5.84171 5.45118 5.64645 5.64645C5.45118 5.84171 5.45118 6.15829 5.64645 6.35355L10.2929 11L5.64645 15.6464C5.45118 15.8417 5.45118 16.1583 5.64645 16.3536C5.84171 16.5488 6.15829 16.5488 6.35355 16.3536L11 11.7071L15.6464 16.3536C15.8417 16.5488 16.1583 16.5488 16.3536 16.3536C16.5488 16.1583 16.5488 15.8417 16.3536 15.6464L11.7071 11L16.3536 6.35355Z" fill="white"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_d_11786_4304" x="-4" y="0" width="30" height="30" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_11786_4304"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_11786_4304" result="shape"/>
+</filter>
+<filter id="filter1_d_11786_4304" x="3.5" y="3.5" width="15" height="15" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_11786_4304"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_11786_4304" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/js/reviewEdit.js
+++ b/js/reviewEdit.js
@@ -7,7 +7,9 @@ const movieTitle = document.querySelector('#movie-title');
 const movieSubTitle = document.querySelector('#movie-title-eng');
 const textRating = document.querySelector('#text-rating');
 const radioRating = document.querySelectorAll('.radio-rating');
+const imgContainer = document.querySelector('.img-container');
 const imgReview = document.querySelector('#img-review');
+const closeButton = document.querySelector('#btn-close');
 const imgInput = document.querySelector('#img-input');
 const textReview = document.querySelector('#text-review');
 const saveButton = document.querySelector('#btn-save');
@@ -73,8 +75,10 @@ window.addEventListener('load', async () => {
         }
         textReview.textContent = contentArray[3];
         if (post.image) {
-            imgReview.classList.remove('disabled');
-            imgReview.src = post.image;
+            if (post.image.includes('mandarin')) {
+                imgContainer.classList.remove('disabled');
+                imgReview.src = post.image;
+            }
         }
         imgUrl = post.image;
     }
@@ -100,12 +104,17 @@ imgInput.addEventListener('change', (e) => {
     fileReader.readAsDataURL(files[0]);
     fileReader.addEventListener('load', () => {
         if (fileReader.result !== null) {
-            imgReview.classList.remove('disabled');
+            imgContainer.classList.remove('disabled');
             img = files[0];
             imgReview.src = fileReader.result.toString();
             target.value = '';
         }
     });
+});
+closeButton.addEventListener('click', () => {
+    img = undefined;
+    imgReview.src = '';
+    imgContainer.classList.add('disabled');
 });
 textReview.addEventListener('keydown', (e) => {
     setTextHeight(e);

--- a/js/reviewEdit.js
+++ b/js/reviewEdit.js
@@ -113,6 +113,7 @@ imgInput.addEventListener('change', (e) => {
 });
 closeButton.addEventListener('click', () => {
     img = undefined;
+    imgUrl = '';
     imgReview.src = '';
     imgContainer.classList.add('disabled');
 });

--- a/js/reviewEdit.ts
+++ b/js/reviewEdit.ts
@@ -13,14 +13,16 @@ const movieSubTitle = document.querySelector(
 ) as HTMLParagraphElement;
 const textRating = document.querySelector('#text-rating') as HTMLSpanElement;
 const radioRating = document.querySelectorAll('.radio-rating');
+const imgContainer = document.querySelector('.img-container') as HTMLElement;
 const imgReview = document.querySelector('#img-review') as HTMLImageElement;
+const closeButton = document.querySelector('#btn-close') as HTMLButtonElement;
 const imgInput = document.querySelector('#img-input') as HTMLInputElement;
 const textReview = document.querySelector('#text-review') as HTMLInputElement;
 const saveButton = document.querySelector('#btn-save') as HTMLButtonElement;
 const loading = document.querySelector('.wrapper-etc') as HTMLElement;
 
 // 서버로 전송할 이미지 (파일 정보가 담김)
-let img: File;
+let img: File | undefined;
 const IMG_MAX_SIZE = 10 * 1024 * 1024;
 // 이미지 url
 let imgUrl: String = '';
@@ -84,8 +86,10 @@ window.addEventListener('load', async () => {
         }
         textReview.textContent = contentArray[3];
         if (post.image) {
-            imgReview.classList.remove('disabled');
-            imgReview.src = post.image;
+            if (post.image.includes('mandarin')) {
+                imgContainer.classList.remove('disabled');
+                imgReview.src = post.image;
+            }
         }
         imgUrl = post.image;
     }
@@ -112,12 +116,18 @@ imgInput.addEventListener('change', (e: Event) => {
     fileReader.readAsDataURL(files[0]);
     fileReader.addEventListener('load', () => {
         if (fileReader.result !== null) {
-            imgReview.classList.remove('disabled');
+            imgContainer.classList.remove('disabled');
             img = files[0];
             imgReview.src = fileReader.result.toString();
             target.value = '';
         }
     });
+});
+
+closeButton.addEventListener('click', () => {
+    img = undefined;
+    imgReview.src = '';
+    imgContainer.classList.add('disabled');
 });
 
 textReview.addEventListener('keydown', (e: Event) => {

--- a/js/reviewEdit.ts
+++ b/js/reviewEdit.ts
@@ -126,6 +126,7 @@ imgInput.addEventListener('change', (e: Event) => {
 
 closeButton.addEventListener('click', () => {
     img = undefined;
+    imgUrl = '';
     imgReview.src = '';
     imgContainer.classList.add('disabled');
 });

--- a/js/writePost.js
+++ b/js/writePost.js
@@ -7,12 +7,13 @@ const movieTitle = document.querySelector('#movie-title');
 const movieSubTitle = document.querySelector('#movie-title-eng');
 const textRating = document.querySelector('#text-rating');
 const radioRating = document.querySelectorAll('.radio-rating');
+const imgContainer = document.querySelector('.img-container');
 const imgReview = document.querySelector('#img-review');
+const closeButton = document.querySelector('#btn-close');
 const imgInput = document.querySelector('#img-input');
 const textReview = document.querySelector('#text-review');
 const saveButton = document.querySelector('#btn-save');
 const loading = document.querySelector('.wrapper-etc');
-// const movieSeq = window.location.search.slice(1);
 const queryString = window.location.search;
 const params = new URLSearchParams(queryString);
 const movieId = params.get('movieId');
@@ -103,12 +104,17 @@ imgInput.addEventListener('change', (e) => {
     fileReader.readAsDataURL(files[0]);
     fileReader.addEventListener('load', () => {
         if (fileReader.result !== null) {
-            imgReview.classList.remove('disabled');
+            imgContainer.classList.remove('disabled');
             img = files[0];
             imgReview.src = fileReader.result.toString();
             target.value = '';
         }
     });
+});
+closeButton.addEventListener('click', () => {
+    img = undefined;
+    imgReview.src = '';
+    imgContainer.classList.add('disabled');
 });
 textReview.addEventListener('keydown', (e) => {
     setTextHeight(e);

--- a/js/writePost.ts
+++ b/js/writePost.ts
@@ -1,7 +1,6 @@
 import { handleUploadImage } from './imageApi.js';
 import { getMovieInfo } from './movieApi.js';
 import { writeReview } from './reviewApi.js';
-
 import { hasToken } from './tokenValid.js';
 
 hasToken();
@@ -14,20 +13,21 @@ const movieSubTitle = document.querySelector(
 ) as HTMLParagraphElement;
 const textRating = document.querySelector('#text-rating') as HTMLSpanElement;
 const radioRating = document.querySelectorAll('.radio-rating');
+const imgContainer = document.querySelector('.img-container') as HTMLElement;
 const imgReview = document.querySelector('#img-review') as HTMLImageElement;
+const closeButton = document.querySelector('#btn-close') as HTMLButtonElement;
 const imgInput = document.querySelector('#img-input') as HTMLInputElement;
 const textReview = document.querySelector('#text-review') as HTMLInputElement;
 const saveButton = document.querySelector('#btn-save') as HTMLButtonElement;
 const loading = document.querySelector('.wrapper-etc') as HTMLElement;
 
-// const movieSeq = window.location.search.slice(1);
 const queryString = window.location.search;
 const params = new URLSearchParams(queryString);
 const movieId = params.get('movieId');
 const movieSeq = params.get('movieSeq');
 
 // 서버로 전송할 이미지 (파일 정보가 담김)
-let img: File;
+let img: File | undefined;
 const IMG_MAX_SIZE = 10 * 1024 * 1024;
 let imgUrl: String = '';
 
@@ -116,12 +116,18 @@ imgInput.addEventListener('change', (e: Event) => {
     fileReader.readAsDataURL(files[0]);
     fileReader.addEventListener('load', () => {
         if (fileReader.result !== null) {
-            imgReview.classList.remove('disabled');
+            imgContainer.classList.remove('disabled');
             img = files[0];
             imgReview.src = fileReader.result.toString();
             target.value = '';
         }
     });
+});
+
+closeButton.addEventListener('click', () => {
+    img = undefined;
+    imgReview.src = '';
+    imgContainer.classList.add('disabled');
 });
 
 textReview.addEventListener('keydown', (e: Event) => {

--- a/pages/reviewEdit.html
+++ b/pages/reviewEdit.html
@@ -131,12 +131,10 @@
                 </div>
                 <div class="review-container">
                     <div class="review-contents">
-                        <img
-                            id="img-review"
-                            class="disabled"
-                            src=""
-                            alt="리뷰 이미지"
-                        />
+                        <div class="img-container disabled">
+                            <img id="img-review" src="" alt="리뷰 이미지" />
+                            <button type="button" id="btn-close"></button>
+                        </div>
                         <textarea
                             name="text-review"
                             id="text-review"

--- a/pages/writePost.html
+++ b/pages/writePost.html
@@ -132,12 +132,10 @@
                 </div>
                 <div class="review-container">
                     <div class="review-contents">
-                        <img
-                            id="img-review"
-                            class="disabled"
-                            src=""
-                            alt="리뷰 이미지"
-                        />
+                        <div class="img-container disabled">
+                            <img id="img-review" src="" alt="리뷰 이미지" />
+                            <button type="button" id="btn-close"></button>
+                        </div>
                         <textarea
                             name="text-review"
                             id="text-review"

--- a/styles/pages/writePost.css
+++ b/styles/pages/writePost.css
@@ -1,427 +1,410 @@
 .header {
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  position: fixed;
-  top: 0;
-  z-index: 9999;
-  width: 100%;
-  background-color: #292929;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: fixed;
+    top: 0;
+    z-index: 9999;
+    width: 100%;
+    background-color: #292929;
 }
 
 .img-logo {
-  height: 90px;
+    height: 90px;
 }
 .img-logo img {
-  margin-left: 90px;
+    margin-left: 90px;
 }
 .img-logo .btn-nav {
-  display: none;
-  position: absolute;
-  top: 33px;
-  right: 33px;
-  width: 25px;
-  height: 25px;
-  background: url(../../assets/icons/menu.svg) no-repeat 0 0;
+    display: none;
+    position: absolute;
+    top: 33px;
+    right: 33px;
+    width: 25px;
+    height: 25px;
+    background: url('../../assets/icons/menu.svg') no-repeat 0 0;
 }
 
 .nav {
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  margin-right: 90px;
-  letter-spacing: -0.02em;
+    display: flex;
+    margin-right: 90px;
+    letter-spacing: -0.02em;
 }
 .nav li {
-  padding-left: 24px;
-  color: #cfcfcf;
-  font-family: "SpoqaHanSansNeo-Bold", sans-serif;
-  font-size: 14px;
-  cursor: pointer;
+    padding-left: 24px;
+    color: #cfcfcf;
+    font-family: 'SpoqaHanSansNeo-Bold', sans-serif;
+    font-size: 14px;
+    cursor: pointer;
 }
 .nav li:hover {
-  color: #ff5f5f;
+    color: #ff5f5f;
 }
-.nav li a .selected {
-  color: #ff5f5f;
+.nav li a.selected {
+    color: #ff5f5f;
 }
 
 .main {
-  margin-top: 90px;
-  position: relative;
-  min-height: calc(100vh - 150px);
+    margin-top: 90px;
+    position: relative;
+    min-height: calc(100vh - 150px);
 }
-.main.wrapper-etc {
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  margin-top: 250px;
-  color: #f1f1f1;
+
+.wrapper-etc {
+    z-index: 100;
+    position: fixed;
+    top: 0;
+    left: 0;
+    margin-top: 90px;
+    min-height: calc(100vh - 150px);
+    width: 100%;
+    height: 100%;
+    background-color: #1e1e1e;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    color: #f1f1f1;
 }
-.main.wrapper-etc .img-etc {
-  width: 181px;
-  margin-bottom: 20px;
+.wrapper-etc .img-etc {
+    width: 181px;
+    margin-bottom: 20px;
 }
-.main.wrapper-etc .text-etc {
-  margin-bottom: 30px;
-  font-family: "SpoqaHanSansNeo-Bold", sans-serif;
-  font-size: 25px;
+.wrapper-etc .text-etc {
+    margin-bottom: 30px;
+    font-family: 'SpoqaHanSansNeo-Bold', sans-serif;
+    font-size: 25px;
+}
+.wrapper-etc.disabled {
+    display: none;
 }
 
 .footer {
-  width: 100%;
-  height: 60px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 9999;
-  background-color: #292929;
-  text-align: center;
+    width: 100%;
+    height: 60px;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 9999;
+    background-color: #292929;
+    text-align: center;
 }
 .footer p {
-  display: inline-block;
-  margin-top: 25px;
-  color: #cfcfcf;
-  font-size: 10px;
+    display: inline-block;
+    margin-top: 25px;
+    color: #cfcfcf;
+    font-size: 10px;
 }
 
 .page-title {
-  font-family: "SpoqaHanSansNeo-Bold", sans-serif;
-  font-size: 30px;
-  text-align: center;
-  color: #f1f1f1;
+    font-family: 'SpoqaHanSansNeo-Bold', sans-serif;
+    font-size: 30px;
+    text-align: center;
+    color: #f1f1f1;
 }
 
 @media screen and (max-width: 768px) {
-  .header {
-    -webkit-box-orient: vertical;
-    -webkit-box-direction: normal;
-        -ms-flex-direction: column;
-            flex-direction: column;
-  }
-  .img-logo img {
-    margin-left: 0;
-  }
-  .img-logo .btn-nav {
-    display: block;
-  }
-  .nav {
-    display: none;
-    -webkit-box-orient: vertical;
-    -webkit-box-direction: normal;
-        -ms-flex-direction: column;
-            flex-direction: column;
-    width: 100%;
-    margin-right: 0;
-  }
-  .nav.active {
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex;
-  }
-  .nav li {
-    width: 100%;
-    padding: 10px 0;
-    text-align: center;
-  }
-  .nav li:last-child {
-    padding-bottom: 20px;
-  }
-  .nav li a {
-    display: block;
-  }
-  .main.active {
-    margin-top: 296px;
-  }
+    .header {
+        flex-direction: column;
+    }
+    .img-logo img {
+        margin: 15px 0 0 0;
+        content: url('../../assets/icons/logo-title-s.svg');
+    }
+    .img-logo .btn-nav {
+        display: block;
+    }
+    .nav {
+        display: none;
+        flex-direction: column;
+        width: 100%;
+        margin-right: 0;
+    }
+    .nav.active {
+        display: flex;
+    }
+    .nav li {
+        width: 100%;
+        padding: 10px 0;
+        text-align: center;
+    }
+    .nav li:last-child {
+        padding-bottom: 20px;
+    }
+    .nav li a {
+        display: block;
+    }
+    .main.active {
+        margin-top: 296px;
+    }
 }
 .write-wrapper {
-  -webkit-box-sizing: content-box;
-          box-sizing: content-box;
-  padding: 60px 20px;
-  max-width: 740px;
-  margin: 0 auto;
-  color: #f1f1f1;
-  overflow: hidden;
+    box-sizing: content-box;
+    padding: 60px 20px;
+    max-width: 740px;
+    margin: 0 auto;
+    color: #f1f1f1;
+    overflow: hidden;
 }
 
 .title-container {
-  margin: 0 auto 5px;
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  gap: 10px;
+    margin: 0 auto 5px;
+    display: flex;
+    text-align: center;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
 }
 .title-container #movie-title {
-  font-family: "SpoqaHanSansNeo-Bold", sans-serif;
-  font-size: 25px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  word-break: keep-all;
-  width: 98%;
-  line-height: 1.4;
+    font-family: 'SpoqaHanSansNeo-Bold', sans-serif;
+    font-size: 25px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    word-break: keep-all;
+    width: 98%;
+    line-height: 1.4;
 }
 .title-container #movie-title-eng {
-  font-family: "SpoqaHanSansNeo-Medium", sans-serif;
-  font-size: 20px;
-  line-height: 1.4;
-  color: #cfcfcf;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  word-break: keep-all;
-  width: 98%;
+    font-family: 'SpoqaHanSansNeo-Medium', sans-serif;
+    font-size: 20px;
+    line-height: 1.4;
+    color: #cfcfcf;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    word-break: keep-all;
+    width: 98%;
 }
 
 .rating-wrapper {
-  margin-left: auto;
-  margin-bottom: 22px;
-  margin-right: 5px;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
-  -webkit-box-align: end;
-      -ms-flex-align: end;
-          align-items: flex-end;
-  gap: 7px;
+    margin-left: auto;
+    margin-bottom: 22px;
+    margin-right: 5px;
+    width: -webkit-fit-content;
+    width: -moz-fit-content;
+    width: fit-content;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-end;
+    gap: 7px;
 }
 .rating-wrapper span {
-  font-size: 12px;
-  line-height: 15px;
+    font-size: 12px;
+    line-height: 15px;
 }
 .rating-wrapper .star-wrapper {
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  gap: 10px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
 }
 .rating-wrapper .star-wrapper #text-rating {
-  padding-top: 4px;
-  font-family: "SpoqaHanSansNeo-Bold", sans-serif;
-  font-size: 16px;
+    padding-top: 4px;
+    font-family: 'SpoqaHanSansNeo-Bold', sans-serif;
+    font-size: 16px;
 }
 .rating-wrapper .radio-container {
-  position: relative;
-  width: 120px;
-  height: 24px;
-  background-image: url(../../assets/icons/stars-gray.svg);
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
+    position: relative;
+    width: 120px;
+    height: 24px;
+    background-image: url(../../assets/icons/stars-gray.svg);
+    display: flex;
 }
 .rating-wrapper .radio-container .radio-rating {
-  cursor: pointer;
-  opacity: 0;
-  width: 12px;
+    cursor: pointer;
+    opacity: 0;
+    width: 12px;
 }
-.rating-wrapper .radio-container .radio-rating:nth-of-type(1):hover ~ .star, .rating-wrapper .radio-container .radio-rating:nth-of-type(1):checked ~ .star {
-  width: 10%;
+.rating-wrapper .radio-container .radio-rating:nth-of-type(1):hover ~ .star,
+.rating-wrapper .radio-container .radio-rating:nth-of-type(1):checked ~ .star {
+    width: 10%;
 }
-.rating-wrapper .radio-container .radio-rating:nth-of-type(2):hover ~ .star, .rating-wrapper .radio-container .radio-rating:nth-of-type(2):checked ~ .star {
-  width: 20%;
+.rating-wrapper .radio-container .radio-rating:nth-of-type(2):hover ~ .star,
+.rating-wrapper .radio-container .radio-rating:nth-of-type(2):checked ~ .star {
+    width: 20%;
 }
-.rating-wrapper .radio-container .radio-rating:nth-of-type(3):hover ~ .star, .rating-wrapper .radio-container .radio-rating:nth-of-type(3):checked ~ .star {
-  width: 30%;
+.rating-wrapper .radio-container .radio-rating:nth-of-type(3):hover ~ .star,
+.rating-wrapper .radio-container .radio-rating:nth-of-type(3):checked ~ .star {
+    width: 30%;
 }
-.rating-wrapper .radio-container .radio-rating:nth-of-type(4):hover ~ .star, .rating-wrapper .radio-container .radio-rating:nth-of-type(4):checked ~ .star {
-  width: 40%;
+.rating-wrapper .radio-container .radio-rating:nth-of-type(4):hover ~ .star,
+.rating-wrapper .radio-container .radio-rating:nth-of-type(4):checked ~ .star {
+    width: 40%;
 }
-.rating-wrapper .radio-container .radio-rating:nth-of-type(5):hover ~ .star, .rating-wrapper .radio-container .radio-rating:nth-of-type(5):checked ~ .star {
-  width: 50%;
+.rating-wrapper .radio-container .radio-rating:nth-of-type(5):hover ~ .star,
+.rating-wrapper .radio-container .radio-rating:nth-of-type(5):checked ~ .star {
+    width: 50%;
 }
-.rating-wrapper .radio-container .radio-rating:nth-of-type(6):hover ~ .star, .rating-wrapper .radio-container .radio-rating:nth-of-type(6):checked ~ .star {
-  width: 60%;
+.rating-wrapper .radio-container .radio-rating:nth-of-type(6):hover ~ .star,
+.rating-wrapper .radio-container .radio-rating:nth-of-type(6):checked ~ .star {
+    width: 60%;
 }
-.rating-wrapper .radio-container .radio-rating:nth-of-type(7):hover ~ .star, .rating-wrapper .radio-container .radio-rating:nth-of-type(7):checked ~ .star {
-  width: 70%;
+.rating-wrapper .radio-container .radio-rating:nth-of-type(7):hover ~ .star,
+.rating-wrapper .radio-container .radio-rating:nth-of-type(7):checked ~ .star {
+    width: 70%;
 }
-.rating-wrapper .radio-container .radio-rating:nth-of-type(8):hover ~ .star, .rating-wrapper .radio-container .radio-rating:nth-of-type(8):checked ~ .star {
-  width: 80%;
+.rating-wrapper .radio-container .radio-rating:nth-of-type(8):hover ~ .star,
+.rating-wrapper .radio-container .radio-rating:nth-of-type(8):checked ~ .star {
+    width: 80%;
 }
-.rating-wrapper .radio-container .radio-rating:nth-of-type(9):hover ~ .star, .rating-wrapper .radio-container .radio-rating:nth-of-type(9):checked ~ .star {
-  width: 90%;
+.rating-wrapper .radio-container .radio-rating:nth-of-type(9):hover ~ .star,
+.rating-wrapper .radio-container .radio-rating:nth-of-type(9):checked ~ .star {
+    width: 90%;
 }
-.rating-wrapper .radio-container .radio-rating:nth-of-type(10):hover ~ .star, .rating-wrapper .radio-container .radio-rating:nth-of-type(10):checked ~ .star {
-  width: 100%;
+.rating-wrapper .radio-container .radio-rating:nth-of-type(10):hover ~ .star,
+.rating-wrapper .radio-container .radio-rating:nth-of-type(10):checked ~ .star {
+    width: 100%;
 }
 .rating-wrapper .radio-container .star {
-  position: absolute;
-  top: 0;
-  left: 0;
-  display: block;
-  height: 24px;
-  background-image: url(../../assets/icons/star-yellow.svg);
-  pointer-events: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    display: block;
+    height: 24px;
+    background-image: url(../../assets/icons/star-yellow.svg);
+    pointer-events: none;
 }
 
 .review-container {
-  position: relative;
-  padding: 40px 37px;
-  height: 425px;
-  background-color: #181717;
-  border-radius: 20px;
+    position: relative;
+    padding: 40px 37px;
+    height: 425px;
+    background-color: #181717;
+    border-radius: 20px;
 }
 .review-container .review-contents {
-  overflow-y: auto;
-  height: 100%;
+    overflow-y: auto;
+    height: 100%;
 }
 .review-container .review-contents::-webkit-scrollbar {
-  width: 8px;
-  border-radius: 60px;
-  scroll-padding: 10%;
+    width: 8px;
+    border-radius: 60px;
+    scroll-padding: 10%;
 }
 .review-container .review-contents::-webkit-scrollbar-thumb {
-  border-radius: 30px;
-  height: 10%;
-  background-color: #242424;
+    border-radius: 30px;
+    height: 10%;
+    background-color: #242424;
 }
-.review-container .review-contents #img-review {
-  display: block;
-  max-width: 250px;
-  max-height: 300px;
-  margin-bottom: 14px;
-  border-radius: 4px;
+.review-container .review-contents .img-container {
+    position: relative;
+    display: block;
+    width: -webkit-fit-content;
+    width: -moz-fit-content;
+    width: fit-content;
+    height: -webkit-fit-content;
+    height: -moz-fit-content;
+    height: fit-content;
+    margin-bottom: 14px;
+    border-radius: 4px;
 }
-.review-container .review-contents #img-review.disabled {
-  display: none;
+.review-container .review-contents .img-container #img-review {
+    max-width: 250px;
+    max-height: 300px;
+    -o-object-fit: cover;
+    object-fit: cover;
+}
+.review-container .review-contents .img-container #btn-close {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 24px;
+    height: 24px;
+    background-image: url('../../assets/icons/icon-close.svg');
+}
+.review-container .review-contents .img-container.disabled {
+    display: none;
 }
 .review-container .review-contents #text-review {
-  resize: none;
-  width: 98%;
-  height: 330px;
-  overflow-y: auto;
-  word-break: break-all;
-  color: #dedede;
-  font-size: 14px;
-  line-height: 1.4;
+    resize: none;
+    width: 98%;
+    height: 330px;
+    overflow-y: auto;
+    word-break: break-all;
+    color: #dedede;
+    font-size: 14px;
+    line-height: 1.4;
 }
 .review-container .review-contents #text-review::-webkit-scrollbar {
-  width: 6px;
-  border-radius: 60px;
-  scroll-padding: 10%;
+    width: 6px;
+    border-radius: 60px;
+    scroll-padding: 10%;
 }
 .review-container .review-contents #text-review::-webkit-scrollbar-thumb {
-  border-radius: 30px;
-  height: 10%;
-  background-color: #242424;
-}
-.review-container .review-contents #text-review::-webkit-input-placeholder {
-  font-family: "SpoqaHanSansNeo-Regular", sans-serif;
-  font-size: 13px;
-  color: #767676;
+    border-radius: 30px;
+    height: 10%;
+    background-color: #242424;
 }
 .review-container .review-contents #text-review::-moz-placeholder {
-  font-family: "SpoqaHanSansNeo-Regular", sans-serif;
-  font-size: 13px;
-  color: #767676;
+    font-family: 'SpoqaHanSansNeo-Regular', sans-serif;
+    font-size: 13px;
+    color: #767676;
 }
 .review-container .review-contents #text-review:-ms-input-placeholder {
-  font-family: "SpoqaHanSansNeo-Regular", sans-serif;
-  font-size: 13px;
-  color: #767676;
-}
-.review-container .review-contents #text-review::-ms-input-placeholder {
-  font-family: "SpoqaHanSansNeo-Regular", sans-serif;
-  font-size: 13px;
-  color: #767676;
+    font-family: 'SpoqaHanSansNeo-Regular', sans-serif;
+    font-size: 13px;
+    color: #767676;
 }
 .review-container .review-contents #text-review::placeholder {
-  font-family: "SpoqaHanSansNeo-Regular", sans-serif;
-  font-size: 13px;
-  color: #767676;
+    font-family: 'SpoqaHanSansNeo-Regular', sans-serif;
+    font-size: 13px;
+    color: #767676;
 }
 .review-container #label-img {
-  background-image: url("../../assets/icons/upload-file.svg");
-  background-size: cover;
-  width: 30px;
-  height: 30px;
-  cursor: pointer;
-  color: transparent;
-  position: absolute;
-  top: 25px;
-  right: 25px;
+    background-image: url('../../assets/icons/upload-file.svg');
+    background-size: cover;
+    width: 30px;
+    height: 30px;
+    cursor: pointer;
+    color: transparent;
+    position: absolute;
+    top: 25px;
+    right: 25px;
 }
 .review-container #img-input {
-  display: none;
+    display: none;
 }
 
 .save {
-  margin-top: 22px;
-  float: right;
+    margin-top: 22px;
+    float: right;
 }
 
 @media screen and (max-width: 768px) {
-  .review-container {
-    padding: 24px;
-  }
-  .review-container #label-img {
-    top: -7px;
-    right: -7px;
-  }
-  .title-container {
-    margin-bottom: 12px;
-  }
-  .title-container #movie-title {
-    font-size: 20px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    word-break: keep-all;
-    width: 96%;
-  }
-  .title-container #movie-title-eng {
-    font-size: 15px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    word-break: keep-all;
-    width: 96%;
-  }
+    .review-container {
+        padding: 24px;
+    }
+    .review-container #label-img {
+        top: -7px;
+        right: -7px;
+    }
+    .title-container {
+        margin-bottom: 12px;
+    }
+    .title-container #movie-title {
+        font-size: 20px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        word-break: keep-all;
+        width: 96%;
+    }
+    .title-container #movie-title-eng {
+        font-size: 15px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        word-break: keep-all;
+        width: 96%;
+    }
 }

--- a/styles/pages/writePost.scss
+++ b/styles/pages/writePost.scss
@@ -13,6 +13,7 @@
 .title-container {
     margin: 0 auto 5px;
     display: flex;
+    text-align: center;
     flex-direction: column;
     justify-content: center;
     align-items: center;
@@ -140,12 +141,26 @@
         height: 100%;
         @include scroll(8px);
 
-        #img-review {
+        .img-container {
+            position: relative;
             display: block;
-            max-width: 250px;
-            max-height: 300px;
+            width: fit-content;
+            height: fit-content;
             margin-bottom: 14px;
             border-radius: 4px;
+            #img-review {
+                max-width: 250px;
+                max-height: 300px;
+                object-fit: cover;
+            }
+            #btn-close {
+                position: absolute;
+                top: 4px;
+                right: 4px;
+                width: 24px;
+                height: 24px;
+                background-image: url('../../assets/icons/icon-close.svg');
+            }
             &.disabled {
                 display: none;
             }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/79434205/187025555-618fbbba-6dd5-4850-bf7e-fbdb0ad4dfad.png)
- 리뷰 작성/수정 시 이미지를 삭제할 수 있는 버튼을 추가하였습니다.
- 현재 리뷰 작성 시 이미지를 첨부하지 않으면 영화의 포스터 이미지를 기본으로 보내주고 있습니다.
그래서 리뷰 수정 시 이미지 경로명에 `mandarin`이 포함되어 있지 않으면 (kmdb에서 받아온 포스터일 경우) 수정 페이지에 뜨지 않도록 하였습니다.
![image](https://user-images.githubusercontent.com/79434205/187025836-4d053994-c072-40ae-ba59-aa8b578bd1ac.png)
- 이미 이미지를 첨부했던 글에서 이미지를 지우고 수정하는 경우에는 포스터가 기본으로 뜨지 않습니다.
이거 거슬리면 말씀해주세요... 뜯어고치겠습니다